### PR TITLE
Fix drawinTitleBar requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Halp, how do I quit Thunderbird?
 
 Through the File menu, or the context menu of the tray icon.
 
+Note that the context menu exit option will not work if you have the Minimize on Close extension installed, in which case you will have to exit through the file menu.
+
 Is there any sort of configuration?
 -----------------------------------
 

--- a/README.md
+++ b/README.md
@@ -48,14 +48,13 @@ it finds the window, injects a library into the Thunderbird process to hook into
 the message queue. TBTray keeps running in the background, in case you want to
 restart Thunderbird at some point.
 
-It doesn't work for me!
+The close button just closes Thunderbird!
 -----------------------
 
 The most likely cause is that you have `mail.tabs.drawInTitlebar` set to `true`
-(which is the default value) - setting it to `false` should solve that problem.
+(which is the default value).
 
-Note: If you want to get this fixed, consider submitting a pull request - I do
-not have the time required to debug and fix a feature I am not using.
+TBTray intercepts the close button by intercepting clicks in the non-client area (the title bar). This doesn't work when `drawInTitlebar` is `true`. A workaround for this is to install the [Minimize on Close](https://addons.thunderbird.net/en-us/thunderbird/addon/minimize-on-close/) extension, which uses client-side javascript to intercept the close event and minimize instead.
 
 Halp, how do I quit Thunderbird?
 --------------------------------

--- a/dll/dllmain.cpp
+++ b/dll/dllmain.cpp
@@ -175,6 +175,10 @@ LRESULT CALLBACK WindowHook(int nCode, WPARAM wParam, LPARAM lParam)
 			ShowWindow(msg.hwnd, SW_HIDE);
 			ShowTray();
 		}
+
+		if (msg.message == WM_DESTROY) {
+			Shell_NotifyIcon(NIM_DELETE, &nid);
+		}
 	}
 
 	return CallNextHookEx(NULL, nCode, wParam, lParam);


### PR DESCRIPTION
Fixes #6 
Hooks `WM_SIZE` instead of `WM_NCLBUTTONDOWN` to determine if window has been minimized, allowing support for Thunderbird's client area buttons when `drawinTitleBar` is set to `true`. 

Unfortunately, I haven't found a way to hook the client area close button, meaning the close button will cause Thunderbird to not minimize to tray while `drawinTitleBar` is `true`.

The `WH_CALLWNDPROC` hook has the ability to determine when the window is closing, but [cannot prevent the close](https://stackoverflow.com/questions/13915332/hook-window-message-loop-wm-close). The `WM_NCLBUTTONDOWN` hook doesn't work because the close button is (as far as I can tell) not in the non-client area when `drawinTitleBar` is `true`.