### PR TITLE
Add note to README.md about Visual C++ requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ this way I didn't have to write most of the boilerplate code.
 Installation
 ------------
 
+Note: Requires _Microsoft Visual C++ Redistributable 2015_ or higher, with same bitness
+([x86](https://aka.ms/vs/16/release/VC_redist.x86.exe), [x64](https://aka.ms/vs/16/release/VC_redist.x64.exe))
+as your Thunderbird.
+
 1. Download the [latest TBTray release](https://github.com/sagamusix/TBTray/releases).
 2. Extract the archive anywhere you want, `%localappdata%\TBTray` would be a
    good place for instance.


### PR DESCRIPTION
Without Visual C++ 2015, TBTray won't start and the following error message pops up:
```
---------------------------
TBTray.exe - System Error
---------------------------
The code execution cannot proceed because VCRUNTIME140.dll was not found.
Reinstalling the program may fix this problem. 
---------------------------
OK   
---------------------------
```